### PR TITLE
fix: Enable fetch API for HttpClient and optimize application configu…

### DIFF
--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -5,12 +5,12 @@ import { provideAnimationsAsync } from '@angular/platform-browser/animations/asy
 import { provideStore } from '@ngrx/store';
 import { provideEffects } from '@ngrx/effects';
 import { provideStoreDevtools } from '@ngrx/store-devtools';
-
 import { routes } from './app.routes';
 import { chartReducer } from './store/chart/chart.reducer';
 import { ChartEffects } from './store/chart/chart.effects';
 import {
   provideHttpClient,
+  withFetch,
   withInterceptorsFromDi,
 } from '@angular/common/http';
 import { provideNativeDateAdapter } from '@angular/material/core';
@@ -26,6 +26,10 @@ export const appConfig: ApplicationConfig = {
       maxAge: 25,
       logOnly: !isDevMode(),
     }),
-    provideHttpClient(withInterceptorsFromDi()),
+    provideHttpClient(
+      withFetch(), // Enable fetch for HttpClient
+      withInterceptorsFromDi()
+    ),
+    provideNativeDateAdapter(),
   ],
 };

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -22,8 +22,6 @@ import { MatDatepickerModule } from '@angular/material/datepicker';
 import { MatNativeDateModule } from '@angular/material/core';
 import { MatDialogModule } from '@angular/material/dialog';
 import { MatButtonModule } from '@angular/material/button';
-
-// Components
 import { CommonModule } from '@angular/common';
 
 // Reducer and Actions
@@ -51,8 +49,6 @@ import { ChartEffects } from './store/chart/chart.effects';
     MatNativeDateModule,
     MatDialogModule,
     MatButtonModule,
-    MatNativeDateModule,
-    MatDatepickerModule,
   ],
   providers: [provideRouter(routes), provideNativeDateAdapter()],
 })


### PR DESCRIPTION
### Description

This PR addresses the issue where Angular detected that `HttpClient` is not configured to use `fetch` APIs. It also ensures the proper configuration of the Angular application for better performance and compatibility.

### Changes Made

1. **Enabled Fetch API for HttpClient**:
   - Updated appConfig to include `withFetch()` in the `provideHttpClient()` call.
   - Improved performance and compatibility, especially for SSR.

2. **Optimized Angular Module Configuration**:
   - Ensured all necessary providers and imports are correctly configured in the `AppModule`.

### Issue Localization - Terminal

NG02801: Angular detected that HttpClient is not configured to use fetch APIs. It's strongly recommended to enable fetch for applications that use Server-Side Rendering for better performance and compatibility. To enable fetch, add the withFetch() to the provideHttpClient() call at the root of the application. 

### How to Test

1. Ensure the application compiles and runs without errors.
2. Verify that `HttpClient` requests use the fetch API.
3. Check the console for any remaining errors or performance warnings.

